### PR TITLE
ADBDEV-9052: Synchronize new resgroup CI 6X to 7X

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -95,7 +95,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v4
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v11
     with:
       version: 7
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## Synchronize new resgroup CI 6X to 7X (#1)

- Target resgroup CI from v4 to v11 tag (see [diff](https://github.com/magf/greengage/pull/1#issuecomment-3695507469) in comments)
- Fix exit code handling in resgroup test script:
  - Combine shell set options into single line
  - Change variable name from EXIT_CODE to exitcode
  - Initialize exitcode with default failure (1)
  - Remove fallback value, exit with actual test exitcode
  - Remove redundant write to log for local run

Now the script explicitly treats any termination as a failure unless the test
suite completes successfully. By initializing exitcode=1 and only setting it
to 0 upon test success (&& exitcode=0), we ensure that any error - whether
from setup, cluster creation, or the tests themselves - results in a proper
failure exit code. This eliminates the previous ambiguity where some failures
might have been masked.