### PR TITLE
ADBDEV-9064: Fix 7X ignore errors in ORCA unit tests

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -77,7 +77,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v9
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v12
     with:
       version: 7
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## Fix 7X ignore errors in ORCA unit tests (#3)

- Target ORCA tests CI to v12 tag (see relevant [diff](https://github.com/magf/greengage/pull/3#issuecomment-3698486827) in comments)
  #### Fix ORCA unit tests to properly fail on errors
  - Remove unconditional redundant success fallback (`|| true`) from log copy command
  - Capture test script exit code in variable for proper propagation
  - Exit container with actual test status instead of last command result
  - Use single quotes to avoid shell variable expansion in container context