### PR TITLE
ADBDEV-9050: Remove caching standard Ubuntu image for 6.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v8
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v13
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
@@ -95,7 +95,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v11
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v13
     with:
       version: 6
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## Remove caching standard Ubuntu image for 6.x

Retarget CI to `v13` ([PR](https://github.com/GreengageDB/greengage-ci/pull/14)) tag:
- for `greengage-reusable-tests-resgroup.ym` main - disable try to cache/restore Ubuntu cloud image
```diff
diff --git a/.github/workflows/greengage-reusable-tests-resgroup.yml b/.github/workflows/greengage-reusable-tests-resgroup.yml
index 41d6748..fc084ac 100644
--- a/.github/workflows/greengage-reusable-tests-resgroup.yml
+++ b/.github/workflows/greengage-reusable-tests-resgroup.yml
@@ -52,13 +52,6 @@ jobs:
           sudo apt update
           sudo DEBIAN_FRONTEND=noninteractive apt install -y qemu-kvm qemu-utils cloud-image-utils libguestfs-tools
 
-      - name: Try to restore Ubuntu cloud image from cache
-        uses: actions/cache@v4
-        id: cache-qemu
-        with:
-          path: ubuntu-22.04.img
-          key:  ubuntu-22.04-image
-
       - name: Download Ubuntu cloud image
         if: steps.cache-qemu.outputs.cache-hit != 'true'
         run: |
```

- for `greengage-reusable-build.yml` additionally - optimize cache image (_don't try to restore, save only_)
```diff
diff --git a/.github/workflows/greengage-reusable-build.yml b/.github/workflows/greengage-reusable-build.yml
index 3e52144..b2dda5e 100644
--- a/.github/workflows/greengage-reusable-build.yml
+++ b/.github/workflows/greengage-reusable-build.yml
@@ -103,7 +103,7 @@ jobs:
 
       # Cache SHA image
       - name: Cache SHA image
-        uses: actions/cache@v4
+        uses: actions/cache/save@v4
         with:
           path: ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}_${{ github.sha }}.tar
           key: ggdb${{ inputs.version }}_${{ inputs.target_os }}${{ inputs.target_os_version }}_${{ github.sha }}
```
Task: [ADBDEV-9050](https://tracker.yandex.ru/ADBDEV-9050)