### PR TITLE
ADBDEV-9120: Collect SQL dump during regression tests for 6.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v8
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v13
     with:
       version: 6
       target_os: ${{ matrix.target_os }}

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v13
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v8
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
@@ -50,7 +50,7 @@ jobs:
 
   regression-tests:
     needs: build
-    if: github.event_name == 'pull_request'  # Only for PR
+    if: github.event_name == 'pull_request' || github.event_name == 'push' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: true
       matrix:
@@ -59,7 +59,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v9
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@ADBDEV-9100
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
@@ -95,7 +95,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v13
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v11
     with:
       version: 6
       target_os: ${{ matrix.target_os }}

--- a/concourse/scripts/dumpdb.bash
+++ b/concourse/scripts/dumpdb.bash
@@ -27,4 +27,4 @@ psql \
 done
 
 pg_dumpall -f ./sqldump/dump.sql
-xz -z ./sqldump/dump.sql
+[ -z "${CI:-}" ] && xz -z ./sqldump/dump.sql

--- a/concourse/scripts/dumpdb.bash
+++ b/concourse/scripts/dumpdb.bash
@@ -26,5 +26,6 @@ psql \
     echo ""
 done
 
+mkdir -p sqldump
 pg_dumpall -f ./sqldump/dump.sql
 [ -z "${CI:-}" ] && xz -z ./sqldump/dump.sql

--- a/concourse/scripts/ic_gpdb.bash
+++ b/concourse/scripts/ic_gpdb.bash
@@ -85,7 +85,6 @@ function _main() {
     fi
 
     if [ "${DUMP_DB}" == "true" ]; then
-        chmod 777 sqldump
         su gpadmin -c ./gpdb_src/concourse/scripts/dumpdb.bash
     fi
 }


### PR DESCRIPTION
## Collect SQL dump during regression tests for 6.x (#8)
### GitHub Actions Workflow (`.github/workflows/greengage-ci.yml`)
- **Reusable workflow version changes:**
  - `greengage-reusable-tests-regression.yml`: v9 → ADBDEV-9100 (switching to feature branch)
- **Regression tests trigger expansion:**
  - Now runs on both PRs **and** pushes to `main` branch
  - Previous: PRs only
  - New condition: `github.event_name == 'pull_request' || github.event_name == 'push' && github.ref == 'refs/heads/main'`

### Database Dump Script (`concourse/scripts/dumpdb.bash`)
- Added `mkdir -p sqldump` to ensure directory exists before dump
- Modified compression behavior: `xz` now skips in CI environments (checks `$CI` variable)
- Removed `chmod 777 sqldump` from `ic_gpdb.bash` (no longer needed with `mkdir -p`)

Task: [ADBDEV-9120](https://tracker.yandex.ru/ADBDEV-9120)