### PR TITLE
GG-128: Don't push to DockerHub when no credentials for 6.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -113,7 +113,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-upload.yml@v9
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-upload.yml@vGG-127
     with:
       version: 6
       target_os: ${{ matrix.target_os }}

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -113,7 +113,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-upload.yml@vGG-127
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-upload.yml@GG-127
     with:
       version: 6
       target_os: ${{ matrix.target_os }}

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -113,7 +113,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-upload.yml@GG-127
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-upload.yml@GG-127-simple
     with:
       version: 6
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## Don't push to DockerHub when no credentials for 6.x (#11)

- Retarget Upload CI to GG-127-simple

Task: [GG-128](https://tracker.yandex.ru/GG-128)