### PR TITLE
CI-5269: Prepare greengage-reusable-build workflow for parallel build 7.x compatibility test

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@v19
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-build.yml@CI-5269
     with:
       version: 7
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## New parallel build 7.x compatibility test
- Retarget build to development branch CI-5269