### PR TITLE
GG-299: Run behave tests in Ubuntu 22.04 and 24.04 for 6.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -40,15 +40,19 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        target_os: [ubuntu]
+        include:
+          - target_os: ubuntu
+          - target_os: ubuntu
+            target_os_version: "24.04"
     permissions:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v24
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v25
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
+      target_os_version: ${{ matrix.target_os_version }}
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Run behave tests in Ubuntu 22.04 and 24.04 for 6.x

- Use matrix Ubuntu 22.04 and 24.04 for behave tests
- Target behave tests CI to v25 tag

Task: [GG-299](https://tracker.yandex.ru/GG-299)