### PR TITLE
GG-322: Rename deb package 'greengage' to 'greengage6'

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -34,81 +34,81 @@ jobs:
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  # behave-tests:
-  #   needs: build  # Wait for build to complete
-  #   if: github.event_name == 'pull_request'  # Only for PR
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       include:
-  #         - target_os: ubuntu
-  #         - target_os: ubuntu
-  #           target_os_version: "24.04"
-  #   permissions:
-  #     contents: read  # Explicit for default behavior
-  #     packages: read  # Explicit for GHCR access clarity
-  #     actions: write  # Required for artifact upload
-  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v26
-  #   with:
-  #     version: 6
-  #     target_os: ${{ matrix.target_os }}
-  #     target_os_version: ${{ matrix.target_os_version }}
-  #   secrets:
-  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  behave-tests:
+    needs: build  # Wait for build to complete
+    if: github.event_name == 'pull_request'  # Only for PR
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - target_os: ubuntu
+          - target_os: ubuntu
+            target_os_version: "24.04"
+    permissions:
+      contents: read  # Explicit for default behavior
+      packages: read  # Explicit for GHCR access clarity
+      actions: write  # Required for artifact upload
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v26
+    with:
+      version: 6
+      target_os: ${{ matrix.target_os }}
+      target_os_version: ${{ matrix.target_os_version }}
+    secrets:
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  # regression-tests:
-  #   needs: build
-  #   if: github.event_name == 'pull_request'  # Only for PR
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       target_os: [ubuntu]
-  #   permissions:
-  #     contents: read  # Explicit for default behavior
-  #     packages: read  # Explicit for GHCR access clarity
-  #     actions: write  # Required for artifact upload
-  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v26
-  #   with:
-  #     version: 6
-  #     target_os: ${{ matrix.target_os }}
-  #   secrets:
-  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  regression-tests:
+    needs: build
+    if: github.event_name == 'pull_request'  # Only for PR
+    strategy:
+      fail-fast: true
+      matrix:
+        target_os: [ubuntu]
+    permissions:
+      contents: read  # Explicit for default behavior
+      packages: read  # Explicit for GHCR access clarity
+      actions: write  # Required for artifact upload
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v26
+    with:
+      version: 6
+      target_os: ${{ matrix.target_os }}
+    secrets:
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  # orca-tests:
-  #   needs: build
-  #   if: github.event_name == 'pull_request'  # Only for PR
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       target_os: [ubuntu]
-  #   permissions:
-  #     contents: read  # Explicit for default behavior
-  #     packages: read  # Explicit for GHCR access clarity
-  #     actions: write  # Required for artifact upload
-  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v19
-  #   with:
-  #     version: 6
-  #     target_os: ${{ matrix.target_os }}
-  #   secrets:
-  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  orca-tests:
+    needs: build
+    if: github.event_name == 'pull_request'  # Only for PR
+    strategy:
+      fail-fast: true
+      matrix:
+        target_os: [ubuntu]
+    permissions:
+      contents: read  # Explicit for default behavior
+      packages: read  # Explicit for GHCR access clarity
+      actions: write  # Required for artifact upload
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v19
+    with:
+      version: 6
+      target_os: ${{ matrix.target_os }}
+    secrets:
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  # resgroup-tests:
-  #   needs: build
-  #   if: github.event_name == 'pull_request'  # Only for PR
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       target_os: [ubuntu]
-  #   permissions:
-  #     contents: read  # Explicit for default behavior
-  #     packages: read  # Explicit for GHCR access clarity
-  #     actions: write  # Required for artifact upload
-  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v23
-  #   with:
-  #     version: 6
-  #     target_os: ${{ matrix.target_os }}
-  #   secrets:
-  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  resgroup-tests:
+    needs: build
+    if: github.event_name == 'pull_request'  # Only for PR
+    strategy:
+      fail-fast: true
+      matrix:
+        target_os: [ubuntu]
+    permissions:
+      contents: read  # Explicit for default behavior
+      packages: read  # Explicit for GHCR access clarity
+      actions: write  # Required for artifact upload
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v23
+    with:
+      version: 6
+      target_os: ${{ matrix.target_os }}
+    secrets:
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
   upload:
     if: github.event_name == 'push'

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -34,81 +34,81 @@ jobs:
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  behave-tests:
-    needs: build  # Wait for build to complete
-    if: github.event_name == 'pull_request'  # Only for PR
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - target_os: ubuntu
-          - target_os: ubuntu
-            target_os_version: "24.04"
-    permissions:
-      contents: read  # Explicit for default behavior
-      packages: read  # Explicit for GHCR access clarity
-      actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v26
-    with:
-      version: 6
-      target_os: ${{ matrix.target_os }}
-      target_os_version: ${{ matrix.target_os_version }}
-    secrets:
-      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  # behave-tests:
+  #   needs: build  # Wait for build to complete
+  #   if: github.event_name == 'pull_request'  # Only for PR
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       include:
+  #         - target_os: ubuntu
+  #         - target_os: ubuntu
+  #           target_os_version: "24.04"
+  #   permissions:
+  #     contents: read  # Explicit for default behavior
+  #     packages: read  # Explicit for GHCR access clarity
+  #     actions: write  # Required for artifact upload
+  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v26
+  #   with:
+  #     version: 6
+  #     target_os: ${{ matrix.target_os }}
+  #     target_os_version: ${{ matrix.target_os_version }}
+  #   secrets:
+  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  regression-tests:
-    needs: build
-    if: github.event_name == 'pull_request'  # Only for PR
-    strategy:
-      fail-fast: true
-      matrix:
-        target_os: [ubuntu]
-    permissions:
-      contents: read  # Explicit for default behavior
-      packages: read  # Explicit for GHCR access clarity
-      actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v26
-    with:
-      version: 6
-      target_os: ${{ matrix.target_os }}
-    secrets:
-      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  # regression-tests:
+  #   needs: build
+  #   if: github.event_name == 'pull_request'  # Only for PR
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       target_os: [ubuntu]
+  #   permissions:
+  #     contents: read  # Explicit for default behavior
+  #     packages: read  # Explicit for GHCR access clarity
+  #     actions: write  # Required for artifact upload
+  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v26
+  #   with:
+  #     version: 6
+  #     target_os: ${{ matrix.target_os }}
+  #   secrets:
+  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  orca-tests:
-    needs: build
-    if: github.event_name == 'pull_request'  # Only for PR
-    strategy:
-      fail-fast: true
-      matrix:
-        target_os: [ubuntu]
-    permissions:
-      contents: read  # Explicit for default behavior
-      packages: read  # Explicit for GHCR access clarity
-      actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v19
-    with:
-      version: 6
-      target_os: ${{ matrix.target_os }}
-    secrets:
-      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  # orca-tests:
+  #   needs: build
+  #   if: github.event_name == 'pull_request'  # Only for PR
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       target_os: [ubuntu]
+  #   permissions:
+  #     contents: read  # Explicit for default behavior
+  #     packages: read  # Explicit for GHCR access clarity
+  #     actions: write  # Required for artifact upload
+  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-orca.yml@v19
+  #   with:
+  #     version: 6
+  #     target_os: ${{ matrix.target_os }}
+  #   secrets:
+  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
-  resgroup-tests:
-    needs: build
-    if: github.event_name == 'pull_request'  # Only for PR
-    strategy:
-      fail-fast: true
-      matrix:
-        target_os: [ubuntu]
-    permissions:
-      contents: read  # Explicit for default behavior
-      packages: read  # Explicit for GHCR access clarity
-      actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v23
-    with:
-      version: 6
-      target_os: ${{ matrix.target_os }}
-    secrets:
-      ghcr_token: ${{ secrets.GITHUB_TOKEN }}
+  # resgroup-tests:
+  #   needs: build
+  #   if: github.event_name == 'pull_request'  # Only for PR
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       target_os: [ubuntu]
+  #   permissions:
+  #     contents: read  # Explicit for default behavior
+  #     packages: read  # Explicit for GHCR access clarity
+  #     actions: write  # Required for artifact upload
+  #   uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-resgroup.yml@v23
+  #   with:
+  #     version: 6
+  #     target_os: ${{ matrix.target_os }}
+  #   secrets:
+  #     ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 
   upload:
     if: github.event_name == 'push'

--- a/gpAux/debian/control
+++ b/gpAux/debian/control
@@ -1,11 +1,11 @@
-Source: greengage
+Source: greengage6
 Maintainer: Greengage <greengage@greengagedb.org>
 Section: database
 Build-Depends: debhelper (>= 13),
 	 dh-python,
 	 lsb-release
 
-Package: greengage
+Package: greengage6
 Architecture: any
 Depends: ${shlibs:Depends},
 	 iproute2,

--- a/gpAux/debian/copyright
+++ b/gpAux/debian/copyright
@@ -1,5 +1,5 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: greengage
+Upstream-Name: greengage6
 Upstream-Contact: GreengageDB Team
 Source: https://github.com/GreengageDB/greengage
 

--- a/gpAux/debian/rules
+++ b/gpAux/debian/rules
@@ -43,4 +43,4 @@ override_dh_auto_install:
 
 override_dh_gencontrol:
 	@echo "=== GENCONTROL GPROOT=$(GPROOT), GPDIR=$(GPDIR), PACKAGE_NAME=$(PACKAGE_NAME) ==="
-	dh_gencontrol -p$(PACKAGE_NAME) -- -VpythonRequires="$(DEPS)" -VpythonConflicts="$(CONFLICTS)"
+	dh_gencontrol -- -VpythonRequires="$(DEPS)" -VpythonConflicts="$(CONFLICTS)"


### PR DESCRIPTION
## Rename deb package `greengage` to `greengage6`
- [upd (deb): rename greengage package to greengage6](https://github.com/magf/greengage/commit/0be4b8544e4074399092f353e5e31adcadc50ce7)

Task: [GG-322](https://tracker.yandex.ru/GG-322)