### PR TITLE
CI-5427: Use conventional filenames for deb-packages in the Release

### DIFF
--- a/.github/workflows/greengage-release.yml
+++ b/.github/workflows/greengage-release.yml
@@ -20,8 +20,7 @@ jobs:
       actions: read
     steps:
       - name: Upload packages to release
-        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v10
+        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@CI-5427
         with:
-          version: ${{ matrix.version }}
           extensions: ${{ matrix.extensions }}
           artifact_name: ${{ matrix.artifact_name }}


### PR DESCRIPTION
## Use conventional filenames for deb-packages in the Release
- Remove `version` from upload-pkgs-to-release parameters
- Retarget upload-pkgs-to-release to CI-5427 branch

Task: [CI-5427](https://tracker.yandex.ru/CI-5427)