### PR TITLE
CI-5431: SQL Dump - repository name must be lowercase

### DIFF
--- a/.github/workflows/greengage-sql-dump.yml
+++ b/.github/workflows/greengage-sql-dump.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Determine Greengage Image name
-        run: echo "IMAGE=ghcr.io/${{ github.repository }}/ggdb${VERSION}_${{ matrix.target_os }}${{ matrix.target_os_version }}:${RUN_HEAD_SHA}" >> $GITHUB_ENV
+        run: echo "IMAGE=ghcr.io/${{ github.repository }}/ggdb${VERSION}_${{ matrix.target_os }}${{ matrix.target_os_version }}:${RUN_HEAD_SHA}" | tr '[:upper:]' '[:lower:]' >> $GITHUB_ENV
 
       - name: Display trigger information
         run: |


### PR DESCRIPTION
## SQL Dump - repository name must be lowercase (#35)

[fix(greengage-sql-dump.yml): lowercase Docker image name](https://github.com/GreengageDB/greengage/commit/8cb02c48e635e11dad1a13fe5c4d0547c618d17d)
- Add `tr '[:upper:]' '[:lower:]'` to the image name generation command

Task: [CI-5431](https://tracker.yandex.ru/CI-5431)