### PR TITLE
CI-5431: SQL Dump - repository name must be lowercase

### DIFF
--- a/.github/workflows/greengage-sql-dump.yml
+++ b/.github/workflows/greengage-sql-dump.yml
@@ -44,7 +44,9 @@ jobs:
 
     steps:
       - name: Determine Greengage Image name
-        run: echo "IMAGE=ghcr.io/${{ github.repository }}/ggdb${VERSION}_${{ matrix.target_os }}${{ matrix.target_os_version }}:${RUN_HEAD_SHA}" | tr '[:upper:]' '[:lower:]' >> $GITHUB_ENV
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}/ggdb${env.VERSION}_${{ matrix.target_os }}${{ matrix.target_os_version }}:${env.RUN_HEAD_SHA}
+        run: echo "IMAGE=${IMAGE,,}" >> $GITHUB_ENV
 
       - name: Display trigger information
         run: |


### PR DESCRIPTION
## SQL Dump - repository name must be lowercase (#36)
refactor(greengage-sql-dump.yml): use bash native lowercase for image name
- Replace `tr '[:upper:]' '[:lower:]'` with bash parameter expansion `${IMAGE,,}`
- Move IMAGE definition to env block for better readability

Task: CI-5431
