### PR TITLE
CI-5589: Collect SQL dump after new image built on 'next' branch

### DIFF
--- a/.github/workflows/greengage-sql-dump.yml
+++ b/.github/workflows/greengage-sql-dump.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - 6.x
       - 7.x
+      - next
 
 env:
   RUN_ID: ${{ github.event.workflow_run.id }}
@@ -17,8 +18,9 @@ env:
   RUN_HEAD_COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
   RUN_HEAD_COMMIT_AUTHOR: ${{ github.event.workflow_run.head_commit.author.name }}
   VERSION: ${{ case(
-    github.event.workflow_run.head_branch == '6.x', '6',
-    github.event.workflow_run.head_branch == '7.x', '7',
+    github.event.workflow_run.head_branch == '6.x',  '6',
+    github.event.workflow_run.head_branch == '7.x',  '7',
+    github.event.workflow_run.head_branch == 'next', '8',
     ''
     ) }}
 


### PR DESCRIPTION
## Collect SQL dump after new image built on 'next' branch

- [ci (sql-dump): add branch 'next' for version 8](https://github.com/magf/greengage/commit/d0cbe7c9f05a88d4bb20f64f4e9a7f31ab80d222)

Task: [CI-5589](https://tracker.yandex.ru/CI-5589)