### PR TITLE
CI-5614: Greengage SQL Dump: verify-dumps-created runs unnecessarily when CI is cancelled

### DIFF
--- a/.github/workflows/greengage-sql-dump.yml
+++ b/.github/workflows/greengage-sql-dump.yml
@@ -26,6 +26,7 @@ env:
 
 jobs:
   create-sql-dump-regression:
+    name: Create SQL Dump
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     if: |
@@ -52,17 +53,16 @@ jobs:
 
       - name: Display trigger information
         run: |
-          cat << EOF
-          ================== Workflow Trigger Information ==================
-          Triggered by:   ${RUN_NAME} (#${RUN_ID})
-          Target branch:  ${RUN_HEAD_BRANCH}
-          Source commit:  ${RUN_HEAD_SHA}
-          Commit message: ${RUN_HEAD_COMMIT_MESSAGE}
-
-          Author: ${RUN_HEAD_COMMIT_AUTHOR}
-
-          Image: ${IMAGE}
-          ==================================================================
+          cat >> $GITHUB_STEP_SUMMARY << EOF
+          ## Workflow Trigger Information
+          | Field          | Value |
+          |----------------|-------|
+          | Triggered by   | ${RUN_NAME} (#${RUN_ID}) |
+          | Target branch  | ${RUN_HEAD_BRANCH} |
+          | Source commit  | \`${RUN_HEAD_SHA}\` |
+          | Commit message | ${RUN_HEAD_COMMIT_MESSAGE} |
+          | Author         | ${RUN_HEAD_COMMIT_AUTHOR} |
+          | Image          | \`${IMAGE}\` |
           EOF
 
       - name: Pull Docker image
@@ -96,17 +96,19 @@ jobs:
       - name: Report artifact info
         if: steps.image-pull.outcome == 'success'
         run: |
-          cat << EOF
-          ==================== SQL Dump Creation Report ====================
-          Artifact name: sqldump_ggdb${{ env.VERSION }}_${{ matrix.target_os }}${{ matrix.target_os_version }}
-          Artifact URL:  https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload.outputs.artifact-id }}
-          ==================================================================
+          cat >> $GITHUB_STEP_SUMMARY << EOF
+          ## SQL Dump Creation Report
+          | Field         | Value |
+          |---------------|-------|
+          | Artifact name | sqldump_ggdb${{ env.VERSION }}_${{ matrix.target_os }}${{ matrix.target_os_version }} |
+          | Artifact URL  | https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload.outputs.artifact-id }} |
           EOF
 
   verify-dumps-created:
+    name: Verify SQL Dump
     runs-on: ubuntu-24.04
     needs: create-sql-dump-regression
-    if: always()
+    if: needs.create-sql-dump-regression.result != 'skipped'
     steps:
       - name: Verify at least one SQL dump was created
         env:


### PR DESCRIPTION
## Greengage SQL Dump: verify-dumps-created runs unnecessarily when CI is cancelled (#45)

[ci (sql-dump): skip dump verify on non-success CI, write step summary](https://github.com/magf/greengage/commit/1acfdbec8b87f1625ab45f666332df9111c8e699)

- Add explicit `name` fields to both jobs for cleaner workflow UI
- Write trigger metadata and artifact report to $GITHUB_STEP_SUMMARY
  as Markdown tables instead of plain stdout so they are visible on
  the workflow Summary page without opening step logs
- Replace `if: always()` in verify-dumps-created with
  `needs.create-sql-dump-regression.result != 'skipped'` to avoid
  a spurious failure when the upstream Greengage CI run is cancelled
  or otherwise does not produce a successful conclusion

Task: [CI-5614](https://tracker.yandex.ru/CI-5614)