### PR TITLE
CI-5678: Move generation of dump.sql to ubuntu24

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -48,7 +48,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v28
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@CI-5678
     with:
       version: 6
       target_os: ${{ matrix.target_os }}
@@ -69,7 +69,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@v28
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-regression.yml@CI-5678
     with:
       version: 6
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## Move generation of dump.sql to ubuntu24

- ci(dump): target behave and regression tests to CI-5678 branch

Task: [CI-5678](https://tracker.yandex.ru/CI-5678)