### PR TITLE
CI-5768: Make deb artifact and cache names OS-specific 6.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -154,7 +154,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@CI-5752
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v38
     with:
       version: 6
       target_os: ${{ matrix.target_os }}

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -154,7 +154,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v37
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@CI-5752
     with:
       version: 6
       target_os: ${{ matrix.target_os }}


### PR DESCRIPTION
## Make deb artifact and cache names OS-specific 6.x

- ci(package): target to CI-5752 branch

Task: [CI-5768](https://tracker.yandex.ru/CI-5768)