### PR TITLE
CI-5752: Delivery of deb-package for Ubuntu 24.04 to Release 6.x

### DIFF
--- a/.github/workflows/greengage-release.yml
+++ b/.github/workflows/greengage-release.yml
@@ -1,4 +1,4 @@
-# Release creation workflow
+# .github/workflows/greengage-release.yml
 name: Greengage release
 
 on:
@@ -11,15 +11,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - artifact_name: deb-packages
-          extensions:    deb ddeb
+        - version: 6
+          target_os: ubuntu
+          target_os_version: '22.04'
+          extensions:  deb ddeb
+          package_dir: deb-packages
+        - version: 6
+          target_os: ubuntu
+          target_os_version: '24.04'
+          extensions:  deb ddeb
+          package_dir: deb-packages
     runs-on: ubuntu-24.04
     permissions:
       contents: write
       actions: read
     steps:
       - name: Upload packages to release
-        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v27
+        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@CI-5752
         with:
-          extensions: ${{ matrix.extensions }}
-          artifact_name: ${{ matrix.artifact_name }}
+          version:     ${{ matrix.version }}
+          extensions:  ${{ matrix.extensions }}
+          package_dir: ${{ matrix.package_dir }}
+          cache_key:   ${{ matrix.package_dir }}-${{ matrix.target_os }}${{ matrix.target_os_version }}-${{ github.sha }}

--- a/.github/workflows/greengage-release.yml
+++ b/.github/workflows/greengage-release.yml
@@ -27,9 +27,10 @@ jobs:
       actions: read
     steps:
       - name: Upload packages to release
-        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@CI-5752
+        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v38
         with:
-          version:     ${{ matrix.version }}
-          extensions:  ${{ matrix.extensions }}
-          package_dir: ${{ matrix.package_dir }}
-          cache_key:   ${{ matrix.package_dir }}-${{ matrix.target_os }}${{ matrix.target_os_version }}-${{ github.sha }}
+          version:           ${{ matrix.version }}
+          extensions:        ${{ matrix.extensions }}
+          package_dir:       ${{ matrix.package_dir }}
+          target_os:         ${{ matrix.target_os }}
+          target_os_version: ${{ matrix.target_os_version }}


### PR DESCRIPTION
## Delivery of deb-package for Ubuntu 24.04 to Release 6.x

ci(release): add ubuntu 24.04 to deb package release matrix

- replace file header comment with canonical workflow path
- add version, target_os, target_os_version, package_dir to matrix entries
- add ubuntu 24.04 alongside existing ubuntu 22.04 matrix entry
- replace artifact_name with target_os, target_os_version, package_dir, version
- bump upload-pkgs-to-release v27 to v38

Task: CI-5752
