### PR TITLE
CI-5769: Make deb artifact and cache names OS-specific 7.x

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -146,15 +146,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target_os: [ubuntu]
+        include:
+          - target_os: ubuntu
     permissions:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v28
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v38
     with:
       version: 7
       target_os: ${{ matrix.target_os }}
-      test_docker: ubuntu:22.04 # Docker Image  (e.g., ubuntu:22.04, ubuntu:noble) for deploy test. Skip if empty
+      target_os_version: ${{ matrix.target_os_version }}
+      test_docker: ${{ matrix.target_os }}:${{ matrix.target_os_version || '22.04' }}
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -41,7 +41,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: read  # Explicit for GHCR access clarity
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v28
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-tests-behave.yml@v35
     with:
       version: 7
       target_os: ${{ matrix.target_os }}

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -152,7 +152,7 @@ jobs:
       contents: read  # Explicit for default behavior
       packages: write # Required for GHCR access
       actions: write  # Required for artifact upload
-    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v38
+    uses: greengagedb/greengage-ci/.github/workflows/greengage-reusable-package.yml@v40
     with:
       version: 7
       target_os: ${{ matrix.target_os }}

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1841,6 +1841,10 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("ALTER", "POLICY", MatchAny, "ON", MatchAny, "WITH", "CHECK"))
 		COMPLETE_WITH("(");
 
+	/* ALTER RESOURCE GROUP <name> */
+	else if (TailMatches("ALTER", "RESOURCE", "GROUP", MatchAny))
+		COMPLETE_WITH("SET");
+
 	/* ALTER RULE <name>, add ON */
 	else if (Matches("ALTER", "RULE", MatchAny))
 		COMPLETE_WITH("ON");
@@ -2734,28 +2738,42 @@ psql_completion(const char *text, int start, int end)
 	else if (Matches("CREATE", "ROLE|USER|GROUP", MatchAny, "IN"))
 		COMPLETE_WITH("GROUP", "ROLE");
 
-/* CREATE/DROP RESOURCE GROUP/QUEUE */
-	else if (Matches("CREATE|DROP", "RESOURCE"))
-	 {
-		static const char *const list_CREATERESOURCEGROUP[] =
-		{"GROUP", "QUEUE", NULL};
+/* ALTER/CREATE/DROP RESOURCE GROUP/QUEUE */
+	else if (Matches("ALTER|CREATE|DROP", "RESOURCE"))
+		COMPLETE_WITH("GROUP", "QUEUE");
 
-		COMPLETE_WITH_LIST(list_CREATERESOURCEGROUP);
-	 }
-	/* CREATE/DROP RESOURCE GROUP */
-	else if (TailMatches("CREATE|DROP", "RESOURCE", "GROUP"))
+	/* ALTER/CREATE/DROP RESOURCE GROUP */
+	else if (TailMatches("ALTER|CREATE|DROP", "RESOURCE", "GROUP"))
 		COMPLETE_WITH_QUERY(Query_for_list_of_resgroups);
+
 	/* CREATE RESOURCE GROUP <name> */
-	else if (TailMatches("CREATE|DROP", "RESOURCE", "GROUP", MatchAny))
+	else if (TailMatches("CREATE", "RESOURCE", "GROUP", MatchAny))
 		COMPLETE_WITH("WITH (");
-	else if (TailMatches("RESOURCE", "GROUP", MatchAny, "WITH", "("))
-	{
-		static const char *const list_CREATERESOURCEGROUP[] =
-		{"CONCURRENCY", "cpu_max_percent", "MEMORY_LIMIT", "MEMORY_REDZONE_LIMIT", NULL};
-
-		COMPLETE_WITH_LIST(list_CREATERESOURCEGROUP);
-	}
-
+	/* RESOURCE GROUP <name> WITH ( / SET */
+	else if (TailMatches("RESOURCE", "GROUP", MatchAny, "WITH", "(") ||
+			 TailMatches("RESOURCE", "GROUP", MatchAny, "SET"))
+		COMPLETE_WITH("CONCURRENCY", "CPU_MAX_PERCENT", "CPU_WEIGHT", "CPUSET",
+					  "MEMORY_LIMIT", "MIN_COST", "IO_LIMIT");
+	else if (TailMatches("RESOURCE", "GROUP", MatchAny, "WITH", "(", MatchAny))
+		COMPLETE_WITH("=");
+	/* Complete IO_LIMIT option with delimeter, tablespaces and options */
+	else if (TailMatches("RESOURCE", "GROUP", MatchAny, "WITH", "(", "IO_LIMIT", "=") ||
+			 TailMatches("RESOURCE", "GROUP", MatchAny, "SET", "IO_LIMIT"))
+		COMPLETE_WITH("'");
+	else if(TailMatches("IO_LIMIT", "=", "'") ||
+			TailMatches("IO_LIMIT", "'"))
+			COMPLETE_WITH_QUERY(Query_for_list_of_tablespaces
+								"UNION SELECT '*'");
+	else if(TailMatches("IO_LIMIT", "=", "'", MatchAny) ||
+			TailMatches("IO_LIMIT", "'", MatchAny))
+		COMPLETE_WITH(":");
+	else if(TailMatches("IO_LIMIT", "=", "'", MatchAny, ":") ||
+			TailMatches("IO_LIMIT", "'", MatchAny, ":"))
+		COMPLETE_WITH("wbps", "rbps", "wiops", "riops");
+	else if(TailMatches("wbps|rbps|wiops|riops"))
+		COMPLETE_WITH("=");
+	else if(TailMatches("wbps|rbps|wiops|riops", "="))
+		COMPLETE_WITH("max");
 
 /* CREATE VIEW --- is allowed inside CREATE SCHEMA, so use TailMatches */
 	/* Complete CREATE VIEW <name> with AS */


### PR DESCRIPTION
## Make deb artifact and cache names OS-specific 7.x

ci(package): adapt package matrix for OS-specific artifact naming
- convert matrix from list to include format
- add target_os_version to matrix and pass it to reusable workflow
- derive test_docker from matrix (target_os:target_os_version || 22.04)
- bump greengage-reusable-package v28 to v38

Task: [CI-5769](https://tracker.yandex.ru/CI-5769)