### PR TITLE
CI-5790: Actualize Upload deb-packages to Releases from 6.x to 7.x

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -43,9 +43,9 @@ operating systems:
 
 ## Release Workflow
 
-A separate workflow `Greengage release` handles the uploading of Debian package
-to GitHub releases. It is triggered when a release is published and uses a
-composite action to manage package deployment.
+A separate workflow `Greengage release` handles the uploading of Debian
+packages to GitHub releases. It is triggered when a release is published and
+uses a composite action to manage package deployment.
 
 ### Key Features
 
@@ -54,8 +54,13 @@ composite action to manage package deployment.
 - **Concurrency:** Uses the same concurrency group as the CI workflow
   (`Greengage CI-${{ github.ref }}`) to ensure proper sequencing and prevent
   race conditions.
-- **Cache-based Artifacts:** Restores built packages from cache using the
+- **Multi-OS Matrix:** Builds and uploads packages for ubuntu 22.04 and
+  ubuntu 24.04 in parallel.
+- **Cache-based Artifacts:** Restores built packages from cache using OS and
   commit SHA as the key, rather than downloading artifacts from previous jobs.
+- **OS-specific Filenames:** Inserts `~{target_os}{target_os_version}` into
+  each package filename before the architecture suffix prior to upload
+  (e.g. `greengage6_6.30.1_amd64.deb` → `greengage6_6.30.1~ubuntu24.04_amd64.deb`).
 - **Manual Recovery:** If the cache is missing, the workflow checks the status
   of the last build for the tag and provides clear instructions for manual
   intervention. It does not automatically trigger builds to avoid infinite
@@ -207,6 +212,10 @@ To use this pipeline:
 > - target_os: ubuntu
 >   target_os_version: "22.04"
 > ```
+>
+> **Note**: The release workflow (`greengage-release.yml`) is exempt from this
+> rule — it explicitly sets `target_os_version` for all matrix entries to
+> ensure unambiguous cache key matching with the build workflow.
 
 ## Additional Documentation
 

--- a/.github/workflows/greengage-release.yml
+++ b/.github/workflows/greengage-release.yml
@@ -1,4 +1,4 @@
-# Release creation workflow
+# .github/workflows/greengage-release.yml
 name: Greengage release
 
 on:
@@ -11,15 +11,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - artifact_name: deb-packages
-          extensions:    deb ddeb
+        - version: 7
+          target_os: ubuntu
+          target_os_version: '22.04'
+          extensions:  deb ddeb
+          package_dir: deb-packages
     runs-on: ubuntu-24.04
     permissions:
       contents: write
       actions: read
     steps:
       - name: Upload packages to release
-        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v27
+        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v38
         with:
-          extensions: ${{ matrix.extensions }}
-          artifact_name: ${{ matrix.artifact_name }}
+          version:           ${{ matrix.version }}
+          extensions:        ${{ matrix.extensions }}
+          package_dir:       ${{ matrix.package_dir }}
+          target_os:         ${{ matrix.target_os }}
+          target_os_version: ${{ matrix.target_os_version }}


### PR DESCRIPTION
## Actualize Upload deb-packages to Releases from 6.x to 7.x

- [ci(release): update Greengage release workflow for 7.x](https://github.com/magf/greengage/commit/624b6380575ca696c627eb16bf84c0d6a846b5bd)

Actualize Upload deb-packages to Releases from 6.x to 7.x
- replace file header comment with canonical workflow path
- add `version`, `target_os`, `target_os_version`, `package_dir` to matrix
- replace `artifact_name` parameter with
  `version`, `target_os`, `target_os_version`, `package_dir`
- bump 'upload-pkgs-to-release' action v27 to v38
  - replace `artifact_name` input with
    `version`, `target_os`, `target_os_version`, `package_dir`
  - construct cache key internally
  - rename packages with OS revision before upload

- [doc(ci): update release workflow](https://github.com/magf/greengage/commit/262d2f0dc59b23d7e5c5d3ebd69312757032faf7)

Task: CI-5790